### PR TITLE
fix compiler wasm loading race condition on browser

### DIFF
--- a/components/load_architecture/creator_uielto_preload_architecture.js
+++ b/components/load_architecture/creator_uielto_preload_architecture.js
@@ -20,11 +20,6 @@
  */
 
 let wasm;
-import("../compiler-pkg/web/creator_compiler.js").then(mod => {
-  mod.default({})
-  wasm = mod
-  color = wasm.Color.Html;
-});
 
   /* jshint esversion: 6 */
 

--- a/js/app.js
+++ b/js/app.js
@@ -279,8 +279,9 @@ try
     /************************
      * Mounted vue instance *
      ************************/
-    mounted(){
+    async mounted(){
       this.validate_browser();
+      await this.load_compiler_wasm();
       uielto_backup.methods.backup_modal(this);
 
       //Pre-load following URL params
@@ -369,6 +370,13 @@ try
       },
 
 
+      // Load compiler wasm module
+      async load_compiler_wasm() {
+        const mod = await import("../compiler-pkg/web/creator_compiler.js");
+        await mod.default({}); // Initialize wasm
+        wasm = mod;
+        color = wasm.Color.Html;
+      },
 
 
       /*************/


### PR DESCRIPTION
Previous loading relied on there being some time between the page loaded and the user clicked a button that loaded an architecture, but this broke when trying to load an example from URL parameters as that happens automatically as the page is loaded. New method handles the async loading correctly to avoid any possible race condition